### PR TITLE
Designing gas runway checks and emergency rebalances that can safely say no

### DIFF
--- a/code/freak.wtf/content/blog/gas-runway-emergency-rebalances.en.md
+++ b/code/freak.wtf/content/blog/gas-runway-emergency-rebalances.en.md
@@ -1,0 +1,120 @@
+---
+title: "Designing gas runway checks and emergency rebalances that can safely say no"
+date: 2026-03-08T09:00:00+02:00
+slug: gas-runway-emergency-rebalances
+---
+
+Over the last few days I finally tackled something that had been quietly bothering me for a while: how fragile automated rebalancing becomes when gas wallets are an afterthought. This week was about making gas a first-class signal, and wiring it into an emergency rebalance flow that is allowed — and expected — to say "no" when conditions aren’t safe.
+
+## Context: automation that depends on invisible wallets
+
+The system manages pools that occasionally need emergency rebalancing: withdrawing from one vault, moving funds, and redeploying into a healthier pool. On paper, the logic for "what" to do was already there.
+
+The missing piece was "can we actually afford to do this right now?" — not in terms of TVL or yield, but in terms of plain old gas.
+
+Previously, gas lived in the background:
+
+- Wallet balances weren’t explicitly modelled as part of system health.
+- There was no shared notion of "runway" (how many rebalances we can afford).
+- RPC failures were treated as "shrug, try later" rather than hard blockers.
+
+That setup works until it doesn’t. A network glitch or a depleted wallet can turn a perfectly reasonable rebalance decision into a half-executed mess.
+
+## Decision: gas as a health signal, not a side note
+
+The first decision was to promote gas into the health model:
+
+- Introduce a service that periodically checks gas balances across chains.
+- Express those balances as **runway**, not raw token amounts.
+- Feed that signal into both the scheduler and the emergency rebalance logic.
+
+The runway formula is deliberately simple and opinionated:
+
+> runway = balance ÷ (350k gas × gasPrice × 2 rebalances/day)
+
+This bakes in assumptions:
+
+- ~350k gas per rebalance is a conservative upper bound.
+- Two rebalances per day per chain is enough to respond to most emergencies.
+- We care more about "days of safety" than about the exact number of transactions.
+
+From there, thresholds are defined in human terms:
+
+- **WARNING** when runway < 7 days.
+- **CRITICAL** when runway < 3 days.
+- The system recommends topping up back to a 14-day target.
+
+The key design choice is that nothing in here is trying to be maximally precise. The goal is to avoid silent degradation, not to squeeze every last bit of efficiency out of gas.
+
+## Trade-off: blocking deployments vs being "nice"
+
+Once gas became a first-class signal, the uncomfortable question surfaced: what should the system do when gas is low?
+
+Two obvious options:
+
+1. Log a warning and let everything continue.
+2. Treat insufficient gas as a **hard failure** and block actions.
+
+I chose (2) for anything critical:
+
+- If a chain’s gas runway is CRITICAL, deployments on that chain are blocked.
+- Emergency rebalances on that chain are skipped with an explicit `insufficient_gas` reason.
+
+This is intentionally unfriendly from a "developer experience" point of view. It surfaces as red lights and blocked actions instead of best-effort retries. But it’s much more honest:
+
+- Operators see immediately when the system is unsafe to act.
+- We avoid half-executed flows caused by running out of gas mid-flight.
+- There’s a single source of truth for "is it safe to touch this chain right now?".
+
+The opposite trade-off would have made incidents quieter but nastier: everything "seems fine" until txs mysteriously fail or get stuck.
+
+## Caching and failure modes: when "no data" means "no"
+
+Another subtle decision: what to do when the gas checks themselves fail.
+
+RPC calls are not free and not perfectly reliable. To avoid turning the system into an RPC spammer, the gas check results are cached for a few minutes when deciding whether it’s safe to deploy.
+
+More importantly, RPC failures are treated as **CRITICAL** for that chain:
+
+- If we can’t read the gas balance, we assume the worst.
+- That blocks deployments and emergency rebalances on that chain.
+
+This is a very opinionated stance: "no data" is interpreted as "unsafe", not "unknown". The practical consequence is fewer mysterious edge cases:
+
+- We don’t accidentally approve a rebalance based on stale or missing data.
+- Any upstream infra issues (RPC outages, misconfigurations) show up as hard blocks.
+
+The price is that transient RPC issues can stop the world for a bit. I’m fine with that: I’d rather debug "why is this blocked?" than "why did we touch this chain while blind?".
+
+## Emergency rebalances: tightening the contract
+
+On top of the gas checks, the emergency rebalance flow itself got stricter:
+
+- Operations like withdrawing from a vault or redeploying funds now run with explicit timeouts.
+- Replacement pools are selected in a more constrained way (e.g. prefer same chain among CRITICAL pools).
+- Skipped rebalances record structured reasons (`rate_limit`, `no_replacement`, `insufficient_gas`, etc.) instead of ad-hoc strings.
+
+The common theme is to make the automation’s decision surface narrower and more explicit:
+
+- Either we can afford to act, in which case we try within strict bounds.
+- Or we can’t, and we say so clearly.
+
+This also makes tests much more meaningful: instead of checking brittle log messages, they assert on well-defined fields and state transitions.
+
+## What I’m still unsure about
+
+A few open questions remain:
+
+- Are the WARNING/CRITICAL thresholds aggressive enough for real-world volatility?
+- Should different chains have different runway assumptions (gas cost, typical activity)?
+- How noisy will this be in practice — will operators start ignoring warnings?
+
+Right now the thresholds are deliberately conservative. I’d rather over-alert on potential gas exhaustion and tune it down later, based on real incidents.
+
+Another question is where to surface these signals: logs are not enough. This probably needs to end up in whatever monitoring/dashboarding exists around the system.
+
+## Takeaway
+
+The main lesson from this week is that **automation needs permission to say "no"**.
+
+By turning gas from an invisible constraint into a first-class health signal — and wiring that into emergency flows as a hard blocker — the system becomes less magical but much more trustworthy. I’d rather deal with a loud, stubborn "I refuse to rebalance" than quietly ship a half-broken rescue tx in the dark.

--- a/code/freak.wtf/content/blog/gas-runway-emergency-rebalances.es.md
+++ b/code/freak.wtf/content/blog/gas-runway-emergency-rebalances.es.md
@@ -1,0 +1,120 @@
+---
+title: "Diseñando checks de gas y rebalances de emergencia que puedan decir que no"
+date: 2026-03-08T09:00:00+02:00
+slug: gas-runway-emergency-rebalances
+---
+
+Estos días por fin he atacado algo que llevaba tiempo molestando en segundo plano: lo frágil que se vuelve el rebalanceo automático cuando las wallets de gas son un detalle secundario. La semana ha ido de convertir el gas en una señal de primera clase y conectarlo con un flujo de rebalanceo de emergencia que pueda —y deba— decir "no" cuando las condiciones no son seguras.
+
+## Contexto: automatización que depende de wallets invisibles
+
+El sistema gestiona pools que a veces necesitan un rebalanceo de emergencia: retirar de un vault, mover fondos y redeplegar en un pool más sano. Sobre el papel, la lógica de "qué" hacer ya existía.
+
+Lo que faltaba era el "¿podemos realmente permitirnos hacer esto ahora mismo?" — no en términos de TVL o yield, sino en gas puro y duro.
+
+Antes, el gas vivía en el fondo del sistema:
+
+- Los balances de las wallets no se modelaban explícitamente como parte de la salud.
+- No había una noción compartida de "runway" (cuántos rebalances nos podemos permitir).
+- Los fallos de RPC se trataban como "meh, ya reintentará" en vez de bloqueantes duros.
+
+Ese enfoque funciona… hasta que deja de funcionar. Un glitch de red o una wallet vacía pueden convertir una decisión de rebalanceo perfectamente razonable en un desastre medio ejecutado.
+
+## Decisión: el gas como señal de salud, no como nota al margen
+
+La primera decisión fue subir el gas al modelo de salud:
+
+- Introducir un servicio que revise periódicamente los balances de gas en todas las chains.
+- Expresar esos balances como **runway**, no como cantidades crudas de tokens.
+- Alimentar esa señal tanto al scheduler como a la lógica de rebalanceo de emergencia.
+
+La fórmula de runway es deliberadamente simple y opinada:
+
+> runway = balance ÷ (350k gas × gasPrice × 2 rebalances/día)
+
+Esto fija varios supuestos:
+
+- ~350k gas por rebalance es un upper bound conservador.
+- Dos rebalances al día por chain bastan para reaccionar a la mayoría de emergencias.
+- Nos importa más hablar en "días de seguridad" que en número exacto de transacciones.
+
+A partir de ahí, los umbrales se definen en términos humanos:
+
+- **WARNING** cuando el runway < 7 días.
+- **CRITICAL** cuando el runway < 3 días.
+- El sistema recomienda hacer top-up hasta un objetivo de 14 días.
+
+La clave es que nada de esto intenta ser ultra preciso. El objetivo es evitar degradaciones silenciosas, no exprimir cada gota de eficiencia del gas.
+
+## Trade-off: bloquear despliegues vs ser "amable"
+
+Una vez el gas se convierte en señal de primera clase, aparece la pregunta incómoda: ¿qué hace el sistema cuando el gas es bajo?
+
+Hay dos opciones obvias:
+
+1. Loguear un warning y dejar que todo siga.
+2. Tratar la falta de gas como **fallo duro** y bloquear acciones.
+
+He elegido (2) para todo lo crítico:
+
+- Si el runway de gas de una chain es CRITICAL, los despliegues en esa chain se bloquean.
+- Los rebalances de emergencia en esa chain se marcan como skip con un motivo explícito `insufficient_gas`.
+
+Esto es intencionadamente poco amigable desde el punto de vista de DX. Se traduce en luces rojas y acciones bloqueadas en lugar de reintentos best-effort. Pero es mucho más honesto:
+
+- Los operadores ven inmediatamente cuándo el sistema no es seguro para actuar.
+- Evitamos flujos medio ejecutados por quedarnos sin gas a mitad.
+- Hay una única fuente de verdad para "¿es seguro tocar esta chain ahora mismo?".
+
+El trade-off contrario habría hecho los incidentes más silenciosos pero más feos: todo "parece bien" hasta que las tx empiezan a fallar o quedarse atascadas sin un motivo claro.
+
+## Cache y modos de fallo: cuando "sin datos" significa "no"
+
+Otra decisión sutil: qué hacer cuando el propio check de gas falla.
+
+Las llamadas RPC no son gratis ni perfectas. Para evitar convertir el sistema en un spammer de RPC, los resultados de los checks se cachean unos minutos cuando se decide si es seguro desplegar.
+
+Más importante todavía: los fallos de RPC se tratan como **CRITICAL** para esa chain:
+
+- Si no podemos leer el balance de gas, asumimos lo peor.
+- Eso bloquea despliegues y rebalances de emergencia en esa chain.
+
+Esta postura es muy opinada: "sin datos" se interpreta como "inseguro", no como "desconocido". La consecuencia práctica es que hay menos edge cases raros:
+
+- No aprobamos un rebalance basándonos en datos obsoletos o inexistentes.
+- Cualquier problema de infraestructura upstream (caídas de RPC, malas configs) se manifiesta como bloqueo duro.
+
+El precio es que issues transitorios de RPC pueden parar el mundo un rato. Me parece un buen intercambio: prefiero debuggear "¿por qué está bloqueado esto?" que "¿por qué tocamos esta chain a ciegas?".
+
+## Rebalances de emergencia: apretar el contrato
+
+Encima de los checks de gas, el flujo de rebalanceo de emergencia también se ha endurecido:
+
+- Operaciones como retirar de un vault o redeplegar fondos ahora tienen timeouts explícitos.
+- La selección de pools de reemplazo es más restrictiva (por ejemplo, preferir misma chain entre pools en estado CRITICAL).
+- Los rebalances saltados registran motivos estructurados (`rate_limit`, `no_replacement`, `insufficient_gas`, etc.) en lugar de strings ad-hoc.
+
+El patrón común es hacer que la superficie de decisión de la automatización sea más estrecha y explícita:
+
+- O bien nos podemos permitir actuar, y lo intentamos dentro de límites claros.
+- O bien no, y lo decimos de forma clara.
+
+Esto también hace que los tests sean mucho más útiles: en vez de comprobar mensajes de log frágiles, asertan sobre campos y transiciones de estado bien definidos.
+
+## Dudas que quedan
+
+Quedan varias preguntas abiertas:
+
+- ¿Son los umbrales de WARNING/CRITICAL lo bastante agresivos para la volatilidad real?
+- ¿Deberían distintas chains tener supuestos de runway diferentes (coste de gas, actividad típica)?
+- ¿Cuánto ruido generará esto en la práctica? ¿acabará la gente ignorando los warnings?
+
+De momento los umbrales son deliberadamente conservadores. Prefiero sobre-alertar sobre posible agotamiento de gas y afinar hacia abajo más adelante, a partir de incidentes reales.
+
+Otra duda es dónde exponer estas señales: los logs no son suficientes. Probablemente esto tenga que acabar en el sistema de monitorización/dashboarding que envuelve al sistema.
+
+## Idea clave
+
+La lección de la semana: **la automatización necesita permiso para decir "no"**.
+
+Al convertir el gas de restricción invisible en señal de salud de primera clase —y engancharla a los flujos de emergencia como bloqueante duro— el sistema pierde un poco de magia pero gana mucha más confianza. Prefiero un "me niego a rebalancear" ruidoso y cabezota que un "he intentado salvarte" que se queda a medias en la oscuridad.


### PR DESCRIPTION
Weekly technical journal post about turning gas balance into a first-class health signal, defining runway-based thresholds, and wiring that into emergency rebalance flows that are allowed to block unsafe actions (deployments and emergency moves) instead of failing silently.

It covers the reasoning behind conservative thresholds, fail-safe handling of RPC failures, and making automation explicitly able to say 'no' when gas conditions are not safe.